### PR TITLE
handle: preload.ts:63 Uncaught Error: playerHandle.triggereNextEpisod…

### DIFF
--- a/src/renderer/util/video-commands-handler.ts
+++ b/src/renderer/util/video-commands-handler.ts
@@ -30,7 +30,9 @@ export const videoCommandsHandler = (
       playerHandle?.setVolume((prev) => Math.min(prev + 0.1, 1));
       break;
     case "nextEpisode":
-      playerHandle?.triggereNextEpisode();
+      if (playerHandle && playerHandle.triggereNextEpisode) {
+        playerHandle.triggereNextEpisode();
+      }
       break;
     case "speed-1":
     case "speed-1.25":


### PR DESCRIPTION
…e is not a function

    at IpcRenderer.eval (preload.ts:63:13)
    at IpcRenderer.emit (VM4 sandbox_bundle:2:45997)
    at Object.onMessage (VM4 sandbox_bundle:2:119512). When there is no next episode.