### PR TITLE
FIX ERROR: react-dom-client.development.js:11 An empty string ("") wa…

### DIFF
--- a/src/renderer/components/video-player/video.tsx
+++ b/src/renderer/components/video-player/video.tsx
@@ -42,7 +42,7 @@ const Video: React.FC<VideoProps> = ({
       className="h-full w-full object-contain"
       controls={!isMkv}
       playsInline
-      src={videoUrl}
+      src={videoUrl || null}
       onClick={onClick}
       onError={(e) => {
         const error = e.currentTarget.error;


### PR DESCRIPTION
…s passed to the src attribute. This may cause the browser to download the whole page again over the network. To fix this, either do not render the element at all or pass null to src instead of an empty string.